### PR TITLE
fix: enable Render auto-deployment for staging

### DIFF
--- a/backend-v2/frontend-v2/components/ui/badge.tsx
+++ b/backend-v2/frontend-v2/components/ui/badge.tsx
@@ -1,0 +1,42 @@
+import * as React from "react"
+import { cva, type VariantProps } from "class-variance-authority"
+
+import { cn } from "@/lib/utils"
+
+const badgeVariants = cva(
+  "inline-flex items-center rounded-full border px-2.5 py-0.5 text-xs font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2",
+  {
+    variants: {
+      variant: {
+        default:
+          "border-transparent bg-primary text-primary-foreground hover:bg-primary/80",
+        secondary:
+          "border-transparent bg-secondary text-secondary-foreground hover:bg-secondary/80",
+        destructive:
+          "border-transparent bg-destructive text-destructive-foreground hover:bg-destructive/80",
+        outline: "text-foreground",
+        success:
+          "border-transparent bg-green-100 text-green-800 hover:bg-green-200",
+        warning:
+          "border-transparent bg-yellow-100 text-yellow-800 hover:bg-yellow-200",
+        info:
+          "border-transparent bg-blue-100 text-blue-800 hover:bg-blue-200",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  }
+)
+
+export interface BadgeProps
+  extends React.HTMLAttributes<HTMLDivElement>,
+    VariantProps<typeof badgeVariants> {}
+
+function Badge({ className, variant, ...props }: BadgeProps) {
+  return (
+    <div className={cn(badgeVariants({ variant }), className)} {...props} />
+  )
+}
+
+export { Badge, badgeVariants }

--- a/render.staging.yaml
+++ b/render.staging.yaml
@@ -91,7 +91,7 @@ services:
       - key: SENTRY_ENVIRONMENT
         value: staging
     healthCheckPath: /health
-    autoDeploy: false  # Manual deploy for staging
+    autoDeploy: true  # Auto-deploy on staging branch changes
     branch: staging  # Deploy from staging branch
     numInstances: 1
     
@@ -132,7 +132,7 @@ services:
       - key: NEXT_PUBLIC_SHOW_TEST_DATA
         value: "true"
     healthCheckPath: /
-    autoDeploy: false  # Manual deploy for staging
+    autoDeploy: true  # Auto-deploy on staging branch changes
     branch: staging  # Deploy from staging branch
     numInstances: 1
 


### PR DESCRIPTION
## Summary
Enables automatic deployment on Render for staging environment + fixes missing Badge component.

## Changes Made

### ✅ Render Auto-Deployment
- **Before**: `autoDeploy: false` (manual deployment required)
- **After**: `autoDeploy: true` (automatic deployment on staging branch changes)
- **Impact**: No more manual deployment needed - Render automatically deploys when staging branch is updated

### ✅ Missing Badge Component
- Added missing Badge UI component that was causing build failures
- Includes all variants: default, secondary, destructive, outline, success, warning, info
- Follows shadcn/ui design patterns with class-variance-authority

## Problem Solved
Currently when PRs are merged to staging, you have to manually deploy in Render dashboard. This change makes it **fully automatic**:

1. ✅ PR merged to staging
2. ✅ Render detects branch change 
3. ✅ Automatic deployment starts
4. ✅ Staging environment updated

## Build Issue Fixed
Multiple pages were failing to build due to missing Badge component:
- client-dashboard/page.tsx
- commissions/page.tsx  
- services/dashboard/page.tsx
- admin/users/page.tsx
- agents/analytics/page.tsx

## Test Plan
- [x] render.staging.yaml updated with autoDeploy: true
- [x] Badge component created with proper TypeScript types
- [x] Component follows existing UI patterns
- [ ] Verify auto-deployment works after merge

## Next Steps
After this is merged, any future PR merges to staging will automatically trigger Render deployment without manual intervention.

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>