### PR TITLE
Fix: Replace path aliases with relative imports for Render build

### DIFF
--- a/backend-v2/frontend-v2/app/(auth)/appointments/export/page.tsx
+++ b/backend-v2/frontend-v2/app/(auth)/appointments/export/page.tsx
@@ -1,14 +1,14 @@
 'use client'
 
 import React, { useState, useEffect } from 'react'
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
-import { BulkSelectableAppointmentList } from '@/components/appointments/BulkSelectableAppointmentList'
-import { EnhancedCalendarExport } from '@/components/calendar/EnhancedCalendarExport'
-import { Appointment } from '@/types/appointment'
-import { Alert, AlertDescription } from '@/components/ui/alert'
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '../../../../components/ui/card'
+import { BulkSelectableAppointmentList } from '../../../../components/appointments/BulkSelectableAppointmentList'
+import { EnhancedCalendarExport } from '../../../../components/calendar/EnhancedCalendarExport'
+import { Appointment } from '../../../../types/appointment'
+import { Alert, AlertDescription } from '../../../../components/ui/alert'
 import { InfoIcon } from 'lucide-react'
-import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
-import { useToast } from '@/hooks/use-toast'
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '../../../../components/ui/tabs'
+import { useToast } from '../../../../hooks/use-toast'
 
 // Mock data generator for demonstration
 function generateMockAppointments(): Appointment[] {


### PR DESCRIPTION
## Summary
- 🔧 Replace @/ path aliases with relative imports in appointment export page
- ✅ Fix "Module not found" errors in Render build environment
- 🚀 Ensure all components can be resolved during production build

## Root Cause
Render's build environment couldn't resolve @/ path aliases, causing:
```
Module not found: Can't resolve '@/components/ui/card'
Module not found: Can't resolve '@/components/appointments/BulkSelectableAppointmentList'
Module not found: Can't resolve '@/components/calendar/EnhancedCalendarExport'
```

## Solution
Replaced path aliases with explicit relative imports:
- `@/components/ui/card` → `../../../../components/ui/card`
- `@/components/appointments/BulkSelectableAppointmentList` → `../../../../components/appointments/BulkSelectableAppointmentList`
- All other imports similarly converted

## Test Plan
- [ ] Frontend build succeeds in Render
- [ ] Appointment export page loads correctly
- [ ] All component imports resolve properly

🤖 Generated with Claude Code