### PR TITLE
Fix: Move TypeScript deps to production dependencies

### DIFF
--- a/backend-v2/frontend-v2/package.json
+++ b/backend-v2/frontend-v2/package.json
@@ -90,6 +90,10 @@
     "sonner": "^2.0.6",
     "tailwind-merge": "^3.3.1",
     "tailwindcss": "^3.4.4",
+    "typescript": "^5.5.3",
+    "@types/react": "^18.3.3",
+    "@types/react-dom": "^18.3.0",
+    "@types/node": "^20.19.4",
     "web-vitals": "^4.2.4",
     "ws": "^8.18.3"
   },
@@ -100,9 +104,6 @@
     "@testing-library/react": "^16.3.0",
     "@testing-library/user-event": "^14.6.1",
     "@types/jest": "^30.0.0",
-    "@types/node": "^20.19.4",
-    "@types/react": "^18.3.3",
-    "@types/react-dom": "^18.3.0",
     "eslint": "^9.30.0",
     "jest": "^29.7.0",
     "jest-environment-jsdom": "^29.7.0",
@@ -114,7 +115,6 @@
     "node-fetch": "^2.7.0",
     "puppeteer": "^24.11.2",
     "ts-node": "^10.9.2",
-    "typescript": "^5.5.3",
     "webpack-bundle-analyzer": "^4.10.2",
     "whatwg-fetch": "^3.6.20"
   }


### PR DESCRIPTION
## Summary
- 🔧 Move TypeScript build dependencies to production dependencies
- ✅ Fix "typescript not found" error in Render build environment
- 🚀 Ensure all required types are available during production build

## Root Cause
Render's build environment couldn't find TypeScript dependencies that were in devDependencies, causing:
```
Please install typescript and @types/react by running:
npm install --save-dev typescript @types/react
```

## Solution
Moved build-critical TypeScript packages to `dependencies`:
- `typescript`: ^5.5.3
- `@types/react`: ^18.3.3
- `@types/react-dom`: ^18.3.0
- `@types/node`: ^20.19.4

## Impact
- ✅ Frontend build should complete successfully
- ✅ All TypeScript compilation will work
- ✅ No more missing package errors

🤖 Generated with Claude Code