### PR TITLE
Fix: API configuration for staging frontend-backend connectivity

### DIFF
--- a/render.staging.yaml
+++ b/render.staging.yaml
@@ -113,6 +113,8 @@ services:
         value: staging
       - key: NEXT_PUBLIC_API_URL
         value: https://sixfb-backend-v2-staging.onrender.com
+      - key: NEXT_PUBLIC_API_BASE_URL
+        value: https://sixfb-backend-v2-staging.onrender.com/api/v1
       # Test Stripe publishable key
       - key: NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY
         sync: false  # Set test key in Render dashboard


### PR DESCRIPTION
## Summary
- Add NEXT_PUBLIC_API_BASE_URL environment variable to staging configuration
- Fixes frontend-backend API connection issues in staging environment
- Ensures frontend calls correct /api/v1/ endpoints

## Problem
Frontend staging was unable to connect to backend API, showing "Failed to connect to server" error. Investigation revealed frontend API client was correctly using /api/v1/ paths but environment was missing API_BASE_URL configuration.

## Solution
- Added NEXT_PUBLIC_API_BASE_URL to render.staging.yaml
- Points to correct v1 API endpoints: https://sixfb-backend-v2-staging.onrender.com/api/v1

## Test Plan
- [x] Backend staging is accessible at /api/v1/ endpoints
- [x] Frontend code uses correct /api/v1/ paths in lib/api.ts
- [x] Render configuration updated with correct environment variables

🤖 Generated with Claude Code

Co-Authored-By: Claude <noreply@anthropic.com>