### PR TITLE
Hotfix: Fix loadTimeSlots function reference

### DIFF
--- a/backend-v2/frontend-v2/app/book/BookPageContent.tsx
+++ b/backend-v2/frontend-v2/app/book/BookPageContent.tsx
@@ -861,7 +861,7 @@ export default function BookPage() {
                 ) : (
                   <ErrorDisplay 
                     error={error} 
-                    onRetry={() => selectedDate && fetchTimeSlots(selectedDate)}
+                    onRetry={() => selectedDate && loadTimeSlots(formatDateForAPI(selectedDate))}
                     title="Failed to load time slots"
                   />
                 )}


### PR DESCRIPTION
## Summary
- Fix TypeScript compilation error: `Cannot find name 'fetchTimeSlots'`
- Correct function name from `fetchTimeSlots` to `loadTimeSlots`
- Use proper date formatting with `formatDateForAPI(selectedDate)`

## Root Cause
During merge conflict resolution, the function reference was incorrectly left as `fetchTimeSlots` instead of the correct `loadTimeSlots` from the `useTimeSlotsCache` hook.

## Changes
- Line 864: `fetchTimeSlots(selectedDate)` → `loadTimeSlots(formatDateForAPI(selectedDate))`
- Matches existing usage pattern elsewhere in the file

## Test Plan
- [x] TypeScript compilation passes
- [x] Function reference matches hook export
- [x] Date formatting consistent with rest of file

🔒 Critical hotfix for staging deployment

🤖 Generated with [Claude Code](https://claude.ai/code)