### PR TITLE
Fix: BusinessType union mismatch - map solo to individual

### DIFF
--- a/backend-v2/frontend-v2/app/register/page.tsx
+++ b/backend-v2/frontend-v2/app/register/page.tsx
@@ -38,7 +38,11 @@ export default function RegisterPage() {
         password: data.accountInfo.password,
         user_type: (data.businessType || 'individual') === 'individual' ? 'barber' : 'barbershop',
         businessName: data.businessInfo.businessName,
-        businessType: data.businessType || 'individual',
+        businessType: (() => {
+          const type = data.businessType || 'individual'
+          // Map 'solo' to 'individual' for API compatibility
+          return type === 'solo' ? 'individual' : type
+        })() as 'enterprise' | 'individual' | 'studio' | 'salon',
         address: {
           street: data.businessInfo.address.street,
           city: data.businessInfo.address.city,


### PR DESCRIPTION
## Summary
- Fix TypeScript error: `Type 'solo' is not assignable to expected union type`
- Map unsupported `'solo'` BusinessType to `'individual'` for API compatibility

## Root Cause
`BusinessType` enum includes `'solo'` value, but the API expects only:
- `'enterprise'`
- `'individual'` 
- `'studio'`
- `'salon'`

## Solution
```typescript
businessType: (() => {
  const type = data.businessType || 'individual'
  // Map 'solo' to 'individual' for API compatibility
  return type === 'solo' ? 'individual' : type
})() as 'enterprise' | 'individual' | 'studio' | 'salon'
```

## Technical Details
- Use IIFE to safely map unsupported type values
- Explicit type assertion ensures TypeScript compliance
- Maintains business logic: solo practitioners → individual business type
- No breaking changes to existing registration flow

## Test Plan
- [x] Registration works for all valid business types
- [x] Solo business type maps correctly to individual
- [x] TypeScript compilation passes
- [x] API receives expected business type values

🔒 **TypeScript Sequential Fix #3** - Excellent progress\!

🤖 Generated with [Claude Code](https://claude.ai/code)