### PR TITLE
Fix: shadcn/ui Select component proper usage

### DIFF
--- a/backend-v2/frontend-v2/app/reviews/[id]/page.tsx
+++ b/backend-v2/frontend-v2/app/reviews/[id]/page.tsx
@@ -7,7 +7,7 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/com
 import { Button } from '@/components/ui/button'
 import { Badge } from '@/components/ui/badge'
 import { Input } from '@/components/ui/input'
-import { Select } from '@/components/ui/select'
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert'
 import { Skeleton } from '@/components/ui/skeleton'
 import { useToast } from '@/hooks/use-toast'
@@ -128,13 +128,17 @@ function ResponseEditor({ review, template, onSave, onSend, isLoading }: Respons
             <Select
               value={selectedTemplate}
               onValueChange={setSelectedTemplate}
-              placeholder="Select a template..."
             >
-              {templates.map((template) => (
-                <option key={template.id} value={template.id.toString()}>
-                  {template.name} ({template.category})
-                </option>
-              ))}
+              <SelectTrigger>
+                <SelectValue placeholder="Select a template..." />
+              </SelectTrigger>
+              <SelectContent>
+                {templates.map((template) => (
+                  <SelectItem key={template.id} value={template.id.toString()}>
+                    {template.name} ({template.category})
+                  </SelectItem>
+                ))}
+              </SelectContent>
             </Select>
           </div>
           


### PR DESCRIPTION
## Summary
- Fix TypeScript error: Select component missing 'children' property support
- Implement proper shadcn/ui Select component structure with all required subcomponents

## Root Cause
Code was using incorrect Select component structure:
```typescript
// ❌ WRONG - Using HTML-style options
<Select>
  <option>...</option>
</Select>

// ✅ CORRECT - Using shadcn/ui structure
<Select>
  <SelectTrigger>
    <SelectValue placeholder="..." />
  </SelectTrigger>
  <SelectContent>
    <SelectItem>...</SelectItem>
  </SelectContent>
</Select>
```

## Changes Made
1. **Import**: Added `SelectContent`, `SelectItem`, `SelectTrigger`, `SelectValue` imports
2. **Structure**: Implemented proper shadcn/ui Select component hierarchy
3. **Components**: Replaced `<option>` with `<SelectItem>` for proper typing
4. **Placeholder**: Moved placeholder to `<SelectValue>` component

## Technical Details
- shadcn/ui Select is a composite component requiring specific structure
- TypeScript expects Select children to be SelectTrigger and SelectContent only
- SelectItem provides proper value handling and styling

## Test Plan
- [x] Template selection dropdown renders correctly
- [x] TypeScript compilation passes
- [x] Component behavior unchanged
- [x] UI/UX remains consistent

🔒 **TypeScript Sequential Fix #5** - Almost there\!

🤖 Generated with [Claude Code](https://claude.ai/code)