### PR TITLE
Fix: Custom Select component interface compliance

### DIFF
--- a/backend-v2/frontend-v2/app/reviews/[id]/page.tsx
+++ b/backend-v2/frontend-v2/app/reviews/[id]/page.tsx
@@ -7,7 +7,7 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/com
 import { Button } from '@/components/ui/button'
 import { Badge } from '@/components/ui/badge'
 import { Input } from '@/components/ui/input'
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
+import { Select } from '@/components/ui/select'
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert'
 import { Skeleton } from '@/components/ui/skeleton'
 import { useToast } from '@/hooks/use-toast'
@@ -128,18 +128,12 @@ function ResponseEditor({ review, template, onSave, onSend, isLoading }: Respons
             <Select
               value={selectedTemplate}
               onValueChange={setSelectedTemplate}
-            >
-              <SelectTrigger>
-                <SelectValue placeholder="Select a template..." />
-              </SelectTrigger>
-              <SelectContent>
-                {templates.map((template) => (
-                  <SelectItem key={template.id} value={template.id.toString()}>
-                    {template.name} ({template.category})
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
+              placeholder="Select a template..."
+              options={templates.map((template) => ({
+                value: template.id.toString(),
+                label: `${template.name} (${template.category})`
+              }))}
+            />
           </div>
           
           <div>


### PR DESCRIPTION
## Summary
- Fix TypeScript error: Custom Select component expects `options` prop, not children
- Correct component interface usage for BookedBarber V2 custom Select component

## Root Cause Analysis
Previous fix incorrectly assumed standard shadcn/ui Select component structure. However, BookedBarber V2 uses a custom Select component with different interface:

```typescript
// ❌ WRONG - Standard shadcn/ui pattern
<Select>
  <SelectTrigger>
    <SelectValue />
  </SelectTrigger>
  <SelectContent>
    <SelectItem>...</SelectItem>
  </SelectContent>
</Select>

// ✅ CORRECT - Custom BookedBarber V2 Select
<Select
  options={[{ value: "1", label: "Option 1" }]}
  value={value}
  onValueChange={setValue}
  placeholder="Select..."
/>
```

## Custom Select Interface
BookedBarber V2 Select component expects:
- `options: SelectOption[]` - Array of { value, label } objects
- `value?: string` - Selected value
- `onValueChange?: (value: string) => void` - Change handler
- `placeholder?: string` - Placeholder text

## Changes Made
1. **Removed**: Incorrect shadcn/ui imports (SelectTrigger, SelectContent, etc.)
2. **Added**: Proper options array mapping from templates
3. **Fixed**: Component structure to match custom interface
4. **Maintained**: All existing functionality and behavior

## Test Plan
- [x] Template dropdown renders with all options
- [x] Selection works correctly
- [x] TypeScript compilation passes
- [x] UI/UX unchanged from user perspective

🔒 **TypeScript Sequential Fix #6** - Custom component interface resolved\!

🤖 Generated with [Claude Code](https://claude.ai/code)