### PR TITLE
Fix: Custom Select onChange prop compliance

### DIFF
--- a/backend-v2/frontend-v2/app/reviews/[id]/page.tsx
+++ b/backend-v2/frontend-v2/app/reviews/[id]/page.tsx
@@ -127,7 +127,7 @@ function ResponseEditor({ review, template, onSave, onSend, isLoading }: Respons
             </label>
             <Select
               value={selectedTemplate}
-              onValueChange={setSelectedTemplate}
+              onChange={(value) => setSelectedTemplate(value as string)}
               placeholder="Select a template..."
               options={templates.map((template) => ({
                 value: template.id.toString(),


### PR DESCRIPTION
## Summary
- Fix TypeScript error: `'onValueChange' does not exist on type SelectProps`
- Use correct prop name `onChange` for BookedBarber V2 custom Select component

## Root Cause
Custom Select component interface uses `onChange` prop, not `onValueChange`:
```typescript
// ❌ WRONG
onValueChange={setSelectedTemplate}

// ✅ CORRECT
onChange={(value) => setSelectedTemplate(value as string)}
```

## Custom Select Component Interface
Based on component analysis, the correct interface is:
- `onChange?: (value: string | string[] | null) => void` - Change handler
- `value?: string | string[]` - Current value
- `options: SelectOption[]` - Options array
- `placeholder?: string` - Placeholder text

## Changes Made
1. **Changed**: `onValueChange` → `onChange`
2. **Added**: Proper type casting `(value as string)` for handler
3. **Maintained**: All existing functionality

## Test Plan
- [x] Template selection works correctly
- [x] TypeScript compilation passes  
- [x] Component behavior unchanged
- [x] No UI/UX changes

🔒 **TypeScript Sequential Fix #7** - Custom component prop names matter\!

🤖 Generated with [Claude Code](https://claude.ai/code)